### PR TITLE
fix: add robots and sitemap routes

### DIFF
--- a/web/src/app/robots.ts
+++ b/web/src/app/robots.ts
@@ -1,0 +1,13 @@
+import type { MetadataRoute } from 'next';
+
+const siteUrl = 'https://www.briankeetman.nl';
+
+export default function robots(): MetadataRoute.Robots {
+  return {
+    rules: {
+      userAgent: '*',
+      allow: '/',
+    },
+    sitemap: `${siteUrl}/sitemap.xml`,
+  };
+}

--- a/web/src/app/sitemap.ts
+++ b/web/src/app/sitemap.ts
@@ -1,0 +1,47 @@
+import type { MetadataRoute } from 'next';
+
+import {
+  getPortfolioSlugs,
+  getPostSlugs,
+  getProjectSlugs,
+} from '@/sanity/lib/content';
+
+const siteUrl = 'https://www.briankeetman.nl';
+
+const staticRoutes = ['', '/blog', '/portfolio', '/projects'].map((path) => ({
+  url: `${siteUrl}${path}`,
+  lastModified: new Date(),
+  changeFrequency: 'weekly' as const,
+  priority: path === '' ? 1 : 0.8,
+}));
+
+export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
+  const [posts, portfolioItems, projects] = await Promise.all([
+    getPostSlugs(),
+    getPortfolioSlugs(),
+    getProjectSlugs(),
+  ]);
+
+  const postRoutes = posts.map(({ slug }) => ({
+    url: `${siteUrl}/blog/${slug}`,
+    lastModified: new Date(),
+    changeFrequency: 'monthly' as const,
+    priority: 0.6,
+  }));
+
+  const portfolioRoutes = portfolioItems.map(({ slug }) => ({
+    url: `${siteUrl}/portfolio/${slug}`,
+    lastModified: new Date(),
+    changeFrequency: 'monthly' as const,
+    priority: 0.7,
+  }));
+
+  const projectRoutes = projects.map(({ slug }) => ({
+    url: `${siteUrl}/projects/${slug}`,
+    lastModified: new Date(),
+    changeFrequency: 'monthly' as const,
+    priority: 0.7,
+  }));
+
+  return [...staticRoutes, ...postRoutes, ...portfolioRoutes, ...projectRoutes];
+}


### PR DESCRIPTION
## Summary
- Add a Next.js robots.txt route that allows crawling and points to the sitemap.
- Add a dynamic sitemap.xml route for static pages plus Sanity blog, portfolio and project slugs.

## Test plan
- npm ci
- npm run lint
- npm run build
- Local server check: /robots.txt and /sitemap.xml return 200.

Note: a Vercel preview deployment also built successfully, but direct URL checks are behind Vercel auth/protection.